### PR TITLE
Add version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-NAME    := ev
-VERSION := 0.0.1
-LDFLAGS := -ldflags="-s -w"
+NAME     := ev
+VERSION  := 0.0.1
+REVISION := $(shell git rev-parse --short HEAD)
+LDFLAGS  := -ldflags="-s -w -X \"main.Version=$(VERSION)\" -X \"main.Revision=$(REVISION)\" -extldflags \"-static\""
 
 OS := darwin linux
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func SetVersion(version, revision string) {
+	RootCmd.AddCommand(&cobra.Command{
+		Use:   "version",
+		Short: "Print the version number of ev",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("ev %s (rev=%s)\n", version, revision)
+		},
+	})
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,12 @@ import (
 	"github.com/wantedly/ev/cmd"
 )
 
+var (
+	Version  string
+	Revision string
+)
+
 func main() {
+	cmd.SetVersion(Version, Revision)
 	cmd.Execute()
 }


### PR DESCRIPTION
## REF
https://github.com/wantedly/infrastructure/issues/3326#issuecomment-407349132

## WHY
どの version なのか知りたい時がある

## WHAT
`ev version` コマンドを追加した。

```console
$ ev
CLI tool for managing evaluation result

Usage:
  ev [command]

Available Commands:
  download    Download a file in a target
  help        Help about any command
  ls          List targets in a namespace
  ls-branch   List branches in a namespace
  ls-files    List files in a target
  namespaces  List namespaces
  version     Print the version number of ev

Flags:
  -h, --help   help for ev

Use "ev [command] --help" for more information about a command.

$ ev version
ev 0.0.1 (rev=7d657e7)
```