### PR TITLE
Add upload cmd

### DIFF
--- a/aws/s3/s3.go
+++ b/aws/s3/s3.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/wantedly/ev/aws/session"
+	"io"
 	"strings"
 )
 
@@ -21,6 +22,18 @@ func Download(bucket string, key string) ([]byte, error) {
 		return []byte{}, err
 	}
 	return buff.Bytes(), nil
+}
+
+func Upload(bucket string, key string, r io.Reader) error {
+	uploader := s3manager.NewUploader(session.Session())
+	upParams := &s3manager.UploadInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   r,
+	}
+	// NOTE: UploadOutput is not necessary, so _ is used
+	_, err := uploader.Upload(upParams)
+	return err
 }
 
 func ListFiles(bucket string, prefix string) ([]string, error) {

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
-	"github.com/wantedly/ev/consts"
 	"github.com/wantedly/ev/aws/s3"
+	"github.com/wantedly/ev/consts"
 	"github.com/wantedly/ev/target"
 	"github.com/wantedly/ev/util"
 	"strings"
@@ -41,7 +41,7 @@ func download(cmd *cobra.Command, args []string) error {
 	}
 	file := args[1]
 
-	key := consts.ReportDir + "/" + downloadOpts.namespace + "/" + t + "/" + file
+	key := consts.ReportDir + "/" + downloadOpts.namespace + "/" + target.ToPath(t) + "/" + file
 
 	bytes, err := s3.Download(consts.BucketName, key)
 	if err != nil {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"fmt"
 	"github.com/spf13/cobra"
-	"github.com/wantedly/ev/consts"
 	"github.com/wantedly/ev/aws/s3"
+	"github.com/wantedly/ev/consts"
+	"github.com/wantedly/ev/target"
 	"github.com/wantedly/ev/util"
 )
 
@@ -25,7 +26,7 @@ func init() {
 }
 
 func list(cmd *cobra.Command, args []string) error {
-	fmt.Printf("showing targets in \"%s\" namespace\n", listOpts.namespace)
+	fmt.Printf("Showing targets in \"%s\" namespace\n", listOpts.namespace)
 	keyPrefix := consts.ReportDir + "/" + listOpts.namespace + "/"
 
 	paths, err := s3.ListPaths(consts.BucketName, keyPrefix)
@@ -33,7 +34,7 @@ func list(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	for _, p := range paths {
-		fmt.Printf("%s\n", p)
+		fmt.Printf("%s\n", target.PathTo(p))
 	}
 	return nil
 }

--- a/cmd/list_branch.go
+++ b/cmd/list_branch.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 	"github.com/spf13/cobra"
-	"github.com/wantedly/ev/consts"
 	"github.com/wantedly/ev/aws/s3"
+	"github.com/wantedly/ev/consts"
 	"github.com/wantedly/ev/target"
 	"github.com/wantedly/ev/util"
 )
@@ -26,7 +26,7 @@ func init() {
 }
 
 func listBranch(cmd *cobra.Command, args []string) error {
-	fmt.Printf("showing branches in \"%s\" namespace\n", listBranchOpts.namespace)
+	fmt.Printf("Showing branches in \"%s\" namespace\n", listBranchOpts.namespace)
 	keyPrefix := consts.ReportDir + "/" + listBranchOpts.namespace + "/"
 
 	paths, err := s3.ListPaths(consts.BucketName, keyPrefix)

--- a/cmd/list_files.go
+++ b/cmd/list_files.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
-	"github.com/wantedly/ev/consts"
 	"github.com/wantedly/ev/aws/s3"
+	"github.com/wantedly/ev/consts"
 	"github.com/wantedly/ev/target"
 	"github.com/wantedly/ev/util"
 )
@@ -36,8 +36,8 @@ func listFiles(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("showing files in \"%s\" target\n", listFilesOpts.namespace+"/"+t)
-	keyPrefix := consts.ReportDir + "/" + listFilesOpts.namespace + "/" + t + "/"
+	fmt.Printf("Showing files in \"%s\" target\n", listFilesOpts.namespace+"/"+t)
+	keyPrefix := consts.ReportDir + "/" + listFilesOpts.namespace + "/" + target.ToPath(t) + "/"
 
 	files, err := s3.ListFiles(consts.BucketName, keyPrefix)
 	if err != nil {

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wantedly/ev/aws/s3"
+	"github.com/wantedly/ev/consts"
+	"github.com/wantedly/ev/target"
+	"github.com/wantedly/ev/util"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	currentBranch = "[current branch]"
+	currentCommit = "[current commit]"
+)
+
+var uploadOpts = struct {
+	branch    string
+	commit    string
+	out       string
+	metrics   string
+	namespace string
+}{}
+
+func init() {
+	uploadCmd := &cobra.Command{
+		Use:   "upload",
+		Short: "Upload evaluation result files in a target",
+		Long: `Upload evaluation result files in a target
+
+Example.
+$ ev upload --out ./out.txt \
+            --metrics ./metrics.json \
+            --namespace yashima-category-python`,
+		RunE: upload,
+	}
+
+	uploadCmd.PersistentFlags().StringVarP(&uploadOpts.branch, "branch", "b", currentBranch, "target branch name")
+	uploadCmd.PersistentFlags().StringVarP(&uploadOpts.commit, "commit", "c", currentCommit, "target commithash")
+	uploadCmd.PersistentFlags().StringVarP(&uploadOpts.out, "out", "o", "./out.txt", "target out file")
+	uploadCmd.PersistentFlags().StringVarP(&uploadOpts.metrics, "metrics", "m", "./metrics.json", "target metrics file")
+	uploadCmd.PersistentFlags().StringVarP(&uploadOpts.namespace, "namespace", "n", util.GetWorkingDirectoryName(), "target namespace name")
+
+	RootCmd.AddCommand(uploadCmd)
+}
+
+func upload(cmd *cobra.Command, args []string) error {
+	if uploadOpts.branch == currentBranch {
+		out, err := util.GetCurrentBranch()
+		if err != nil {
+			return err
+		}
+		uploadOpts.branch = out
+	}
+	if uploadOpts.commit == currentCommit {
+		out, err := util.GetCurrentCommit()
+		if err != nil {
+			return err
+		}
+		uploadOpts.commit = out
+	}
+
+	datetime := util.CurrentJSTTime()
+	t, err := target.TargetFrom(datetime, uploadOpts.branch, uploadOpts.commit)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Upload files in \"%s\" target to \"%s\" namespace\n", t, uploadOpts.namespace)
+
+	if err := uploadFile(uploadOpts.namespace, t, "evaluate", uploadOpts.out); err != nil {
+		return err
+	}
+	if err := uploadFile(uploadOpts.namespace, t, "", uploadOpts.metrics); err != nil {
+		return err
+	}
+
+	if err := uploadContext(uploadOpts.namespace, t, uploadOpts.branch, uploadOpts.commit, datetime); err != nil {
+		return err
+	}
+
+	fmt.Printf("Success! Files in \"%s\" target are uploaded!\n", t)
+
+	return nil
+}
+
+func uploadFile(namespace, t, dir, f string) error {
+	keyPrefix := consts.ReportDir + "/" + namespace + "/" + target.ToPath(t)
+	_, filename := filepath.Split(f)
+	var key string
+	if dir == "" {
+		key = keyPrefix + "/" + filename
+	} else {
+		key = keyPrefix + "/" + dir + "/" + filename
+	}
+
+	file, err := os.Open(f)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("uploading %s...\n", f)
+	if err = s3.Upload(consts.BucketName, key, file); err != nil {
+		return err
+	}
+	return nil
+}
+
+type Context struct {
+	Datetime   string `json:"datetime"`
+	Branch     string `json:"branch"`
+	Commithash string `json:"commithash"`
+}
+
+func uploadContext(namespace, t, branch, commithash string, datetime time.Time) error {
+	c := Context{
+		Datetime:   target.FormatTime(datetime),
+		Branch:     branch,
+		Commithash: commithash,
+	}
+	j, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	filename := "context.json"
+	key := consts.ReportDir + "/" + namespace + "/" + target.ToPath(t) + "/" + filename
+	fmt.Printf("uploading %s...\n", filename)
+	if err = s3.Upload(consts.BucketName, key, bytes.NewBuffer(j)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/util/util.go
+++ b/util/util.go
@@ -2,7 +2,14 @@ package util
 
 import (
 	"os"
+	"os/exec"
 	"path"
+	"strings"
+	"time"
+)
+
+var (
+	jstTimeZone = time.FixedZone("Asia/Tokyo", 9*60*60)
 )
 
 func GetWorkingDirectoryName() string {
@@ -10,4 +17,30 @@ func GetWorkingDirectoryName() string {
 		return path.Base(dir)
 	}
 	return ""
+}
+
+func GetCurrentBranch() (string, error) {
+	// NOTE: `git symbolic-ref --short HEAD` can be used for getting current branch
+	// cf. https://qiita.com/sugyan/items/83e060e895fa8ef2038c
+	out, err := exec.Command("git", "symbolic-ref", "--short", "HEAD").Output()
+	if err != nil {
+		return "", err
+	}
+	s := strings.TrimRight(string(out), "\r\n")
+	return strings.TrimRight(s, "\r\n"), err
+}
+
+func GetCurrentCommit() (string, error) {
+	// NOTE: `git rev-parse HEAD` can be used for getting current commit
+	// cf. https://stackoverflow.com/questions/949314/how-to-retrieve-the-hash-for-the-current-commit-in-git
+	out, err := exec.Command("git", "rev-parse", "HEAD").Output()
+	if err != nil {
+		return "", err
+	}
+	s := strings.TrimRight(string(out), "\r\n")
+	return s, err
+}
+
+func CurrentJSTTime() time.Time {
+	return time.Now().In(jstTimeZone)
 }


### PR DESCRIPTION
## REF
https://github.com/wantedly/infrastructure/issues/3326#issuecomment-407349132

## WHY
upload command が欲しい。

## WHAT
追加した。

## Usage
以下の様に利用。

```console
$ ./ev upload --out /tmp/out.txt --metrics /tmp/metrics.json
Upload files in "2018-07-25T21:57:26+09:00-south37/add-upload-cmd-96cbb84" target to "ev" namespace
uploading /tmp/out.txt...
uploading /tmp/metrics.json...
uploading context.json...
Success! Files in "2018-07-25T21:57:26+09:00-south37/add-upload-cmd-96cbb84" target are uploaded!
```