### PR TITLE
Fix help message of sub commands

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -17,8 +17,8 @@ var downloadOpts = struct {
 
 func init() {
 	downloadCmd := &cobra.Command{
-		Use:   "download <target> <file>",
-		Short: "Download a file in a target",
+		Use:   "download <target or branch> <file>",
+		Short: "Download a file in a target or branch",
 		RunE:  download,
 	}
 
@@ -29,7 +29,7 @@ func init() {
 
 func download(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return errors.New("<target> and <file> should be specified!\n")
+		return errors.New("<target or branch> and <file> should be specified!\n")
 	}
 	if len(args) <= 1 {
 		return errors.New("<file> should be specified!\n")

--- a/cmd/list_files.go
+++ b/cmd/list_files.go
@@ -16,8 +16,8 @@ var listFilesOpts = struct {
 
 func init() {
 	listFilesCmd := &cobra.Command{
-		Use:   "ls-files <target>",
-		Short: "List files in a target",
+		Use:   "ls-files <target or branch>",
+		Short: "List files in a target or branch",
 		RunE:  listFiles,
 	}
 
@@ -28,7 +28,7 @@ func init() {
 
 func listFiles(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return errors.New("<target> should be specified!\n")
+		return errors.New("<target or branch> should be specified!\n")
 	}
 
 	t, err := target.Target(args[0], listFilesOpts.namespace)


### PR DESCRIPTION
## REF
https://github.com/wantedly/infrastructure/issues/3326#issuecomment-407793291

## WHY
`target` の箇所には `branch` も指定できる様にしているが、コマンドの help メッセージだけではそれが分からない。

## WHAT
`target` ではなく、`target or branch` と表記する様にした。