### PR TITLE
Update install dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_deploy:
   - make cross-build
   - make dist
   - make publish
-  - mkdir -p public-script && cp script/install.sh public-script/ev
+  - mkdir -p public-script && cp script/install.sh public-script/ev-cli
 deploy:
   - provider: releases
     skip_cleanup: true
@@ -27,7 +27,7 @@ deploy:
     bucket: private-dev-tools.wantedly.com
     skip_cleanup: true
     local-dir: dist/publish
-    upload-dir: ev
+    upload-dir: ev-cli
     acl: public_read
     on:
       tags: true

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Formula is avaliable at wantedly/homebrew-tools.
 
 ```sh-session
 $ brew tap wantedly/tools git@github.com:wantedly/homebrew-tools
-$ brew install ev
+$ brew install ev-cli
 ```
 
 ### Other platforms (Linux)
@@ -22,7 +22,7 @@ You can download executable file at [HERE](https://github.com/wantedly/ev-cli/re
 Or, you can download a script for installation.
 
 ```console
-bash <(curl -sL https://get.wantedlyapp.com/ev)
+bash <(curl -sL https://get.wantedlyapp.com/ev-cli)
 ```
 
 ## Prerequisites
@@ -54,7 +54,7 @@ aws_access_key_id = AK................
 aws_secret_access_key = zX..........................
 ```
 
-`ev` automatically set AWS_REGION as `ap-northeast-1`.
+`ev-cli` automatically set AWS_REGION as `ap-northeast-1`.
 
 ## Usage
 

--- a/script/install.sh
+++ b/script/install.sh
@@ -30,11 +30,11 @@ else
 fi
 
 # download
-echo "Installing ev $EV_VERSION for $OS-$ARCH to $DEST"
+echo "Installing ev-cli $EV_VERSION for $OS-$ARCH to $DEST"
 query=".assets[] | select(.name | contains(\"$OS\") and contains(\"$ARCH\") and contains(\"$EXTENSION\")) | .id"
 id=$(curl -s https://$TOKEN@api.github.com/repos/wantedly/ev-cli/releases/$RELEASE_PATH | jq "$query")
 mkdir -p $DEST
 curl -sLJ -H 'Accept: application/octet-stream' https://$TOKEN@api.github.com/repos/wantedly/ev-cli/releases/assets/$id | tar xz -C $DEST --strip=1 "$OS-$ARCH/ev"
-echo "ev has successfully been installed to $DEST"
+echo "ev-cli has successfully been installed to $DEST"
 echo "You might want to add the line below to the shell profile"
 echo "  export PATH=${DEST/$HOME/\$HOME}:\$PATH"


### PR DESCRIPTION
## WHY
`ev-cli` コマンドなのに `brew install ev-cli` や `bash <(curl -sL https://get.wantedlyapp.com/ev-cli)` はちょっと分かりづらい。

## WHAT
install する際の package 名も `ev-cli` に変更した。
binary の名前だけが、`ev` になる（`aws-cli` の様なイメージ）。