### PR TITLE
Add latest version to publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ publish:
 	mkdir -p dist/publish
 	@for os in $(OS); do \
 		cp ./dist/$(NAME)-v$(VERSION)-$$os-amd64.tar.gz ./dist/publish/; \
+		cp ./dist/$(NAME)-v$(VERSION)-$$os-amd64.tar.gz ./dist/publish/$(NAME)-latest-$$os-amd64.tar.gz; \
 	done
 
 .PHONY: release


### PR DESCRIPTION
## WHY
`latest` として access 出来るものを用意して、直接 download 出切ると嬉しい。
（install script が不要になる）

## WHAT
`version` に `latest` が入るものを用意する様にした。
「最後に build されたもの」が `latest` という扱いになる。

```console
$ ls -1 dist/publish
LICENSE
README.md
ev-latest-darwin-amd64.tar.gz
ev-latest-linux-amd64.tar.gz
```