### PR TITLE
Use errors.Wrap

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -59,6 +59,12 @@
   revision = "0b12d6b5"
 
 [[projects]]
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
   name = "github.com/spf13/cobra"
   packages = ["."]
   revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
@@ -73,6 +79,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0ca9d1df81c677c4b2c1818847f4478710fc8124dfeabc185ddc0286748f1e9c"
+  inputs-digest = "620bf19912b3bb044d53027e12a60f816305d8e21be46ad36afa96715a9227ac"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,3 +27,7 @@
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
   version = "1.x"
+
+[[constraint]]
+  name = "github.com/pkg/errors"
+  version = "0.8.0"

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -8,7 +8,6 @@ import (
 	"github.com/wantedly/ev-cli/consts"
 	"github.com/wantedly/ev-cli/target"
 	"github.com/wantedly/ev-cli/util"
-	"strings"
 )
 
 var downloadOpts = struct {
@@ -45,11 +44,6 @@ func download(cmd *cobra.Command, args []string) error {
 
 	bytes, err := s3.Download(consts.BucketName, key)
 	if err != nil {
-		if err.Error()[:10] == "NoSuchKey:" {
-			// NOTE: Handle NoSuchKey error
-			s := strings.TrimPrefix(key, consts.ReportDir+"/"+downloadOpts.namespace+"/")
-			return errors.New(fmt.Sprintf("NoSuchKey: \"%s\" does not exist", s))
-		}
 		return err
 	}
 	fmt.Printf(string(bytes))

--- a/target/target.go
+++ b/target/target.go
@@ -1,8 +1,8 @@
 package target
 
 import (
-	"errors"
 	"fmt"
+	"github.com/pkg/errors"
 	"github.com/wantedly/ev-cli/aws/s3"
 	"github.com/wantedly/ev-cli/consts"
 	"regexp"
@@ -37,7 +37,7 @@ func Target(t string, namespace string) (string, error) {
 
 	p, err := findLatestMatch(paths, ToPath(branch))
 	if err != nil {
-		return "", errors.New(fmt.Sprintf("%s in \"%s\" namespace", err.Error(), namespace))
+		return "", errors.Wrapf(err, "Error in \"%s\" namespace", namespace)
 	}
 	return PathTo(p), nil
 }


### PR DESCRIPTION
## WHY
`errors.Wrap` can hold the cause of error.

## WHAT
Use `errors.Wrap` instead of `errors.New`